### PR TITLE
Use relative pathing for module path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 
 
 # dependencies
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/tools/build)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/tools/build)
 
 if (WIN32)
   # build libusb


### PR DESCRIPTION
This allows direct embedding in other CMake projects with `add_subdirectory`. It should have no impact on building when it is the root source dir. 