### PR TITLE
Add two CMake options to enable Python bindings or C++ examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required (VERSION 3.5)
 project(crazyflie-link-cpp)
 
+# define some options
+option(BUILD_PYTHON_BINDINGS "Generate Python Bindings" ON)
+option(BUILD_CPP_EXAMPLES "Generate C++ Examples" ON)
 
 # Enable C++14 and warnings
 set(CMAKE_CXX_STANDARD 14)
@@ -91,47 +94,50 @@ target_link_libraries(crazyflieLinkCpp
 set_property(TARGET crazyflieLinkCpp PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # C++ example application
-
-# example_console
-add_executable(example_console
-  examples/console.cpp
-)
-target_link_libraries(example_console
-  crazyflieLinkCpp
-)
-
-# example_scan
-add_executable(example_scan
-  examples/scan.cpp
-)
-target_link_libraries(example_scan
-  crazyflieLinkCpp
-)
-
-# example_benchmark
-add_executable(example_benchmark
-  examples/benchmark.cpp
-)
-target_link_libraries(example_benchmark
-  crazyflieLinkCpp
-)
-
-# example_broadcast
-add_executable(example_broadcast
-  examples/broadcast.cpp
-)
-target_link_libraries(example_broadcast
-  crazyflieLinkCpp
-)
-
-# Python bindings
-add_subdirectory(pybind11)
-
-pybind11_add_module(cflinkcpp
-  src/python_bindings.cpp
-)
-
-target_link_libraries(cflinkcpp
-  PRIVATE
+if (BUILD_CPP_EXAMPLES)
+  # example_console
+  add_executable(example_console
+    examples/console.cpp
+  )
+  target_link_libraries(example_console
     crazyflieLinkCpp
-)
+  )
+
+  # example_scan
+  add_executable(example_scan
+    examples/scan.cpp
+  )
+  target_link_libraries(example_scan
+    crazyflieLinkCpp
+  )
+
+  # example_benchmark
+  add_executable(example_benchmark
+    examples/benchmark.cpp
+  )
+  target_link_libraries(example_benchmark
+    crazyflieLinkCpp
+  )
+
+  # example_broadcast
+  add_executable(example_broadcast
+    examples/broadcast.cpp
+  )
+  target_link_libraries(example_broadcast
+    crazyflieLinkCpp
+  )
+endif()
+
+if (BUILD_PYTHON_BINDINGS)
+  # Python bindings
+  add_subdirectory(pybind11)
+
+  pybind11_add_module(cflinkcpp
+    src/python_bindings.cpp
+  )
+
+  target_link_libraries(cflinkcpp
+    PRIVATE
+      crazyflieLinkCpp
+  )
+endif()


### PR DESCRIPTION
The default remains to build everything, but now individual targets
may be disabled if this repository is used as a submodule.

Addresses issue #16.