### PR TITLE
Fixed issue by changing the CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,11 +49,6 @@ else()
   find_package(libusb REQUIRED)
 endif()
 
-include_directories(
-  include
-  ${LIBUSB_INCLUDE_DIR}
-)
-
 # C++ library
 
 add_library(crazyflieLinkCpp
@@ -66,6 +61,11 @@ add_library(crazyflieLinkCpp
   src/CrazyflieUSBThread.cpp
   src/Version.cpp
 )
+
+#libraries that link with the crazyflieLinkCpp will have access to the 
+# 'include/' directory 
+target_include_directories(crazyflieLinkCpp PUBLIC include/ ${LIBUSB_LIBRARY})
+
 
 # target_include_directories(libCrazyflieLinkCpp
 #   PUBLIC


### PR DESCRIPTION
I have a project which is written in c++ in which I wanted to use the code from this project. In order to do so I added your code as a git-submodule and created a CMakeLists.txt file in order to compile my code and include your code also. What I did was add your code as a sub_directory (`add_subdirectory`) and this built the makefile without errors fine, however when I tried to build the makefile I got an error. The error message said that it couldn't find the header file under `crazyflieLinkCpp/Connection.h`. After tweaking a bit (an with help) I found out that the problem was that is simply did recognize the `include/` directory as a header directory which is weird because you add it like so:

```cmake
include_directories(
  include
  ${LIBUSB_INCLUDE_DIR}
)
````

This should globally add the `include` directory as a header directory, right? But it doesn't for some reason (maybe it was changed in some recent cmake update ¯\_ (ツ)_/¯ ). What fixed the problem was changing the way that you include the header directories, like so:

```cmake
target_include_directories(crazyflieLinkCpp PUBLIC include/ ${LIBUSB_INCLUDE_DIR})
```

After this correction my code compiled smoothly.