### PR TITLE
Feature packet improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 
 if (BUILD_PYTHON_BINDINGS)
   # Python bindings
-  add_subdirectory(pybind11)
+  add_subdirectory(pybind11 EXCLUDE_FROM_ALL)
 
   pybind11_add_module(cflinkcpp
     src/python_bindings.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,12 @@ add_library(crazyflieLinkCpp
 #     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/crazyflie_cpp>
 # )
 
+# Apple macOS libraries
+if (APPLE)
+  set(CMAKE_EXE_LINKER_FLAGS "-lobjc -framework IOKit -framework CoreFoundation")
+  set(CMAKE_MODULE_LINKER_FLAGS "-lobjc -framework IOKit -framework CoreFoundation")
+endif()
+
 # Link pthread on Linux and Mac only
 if (NOT MSVC)
 target_link_libraries(crazyflieLinkCpp
@@ -85,9 +91,6 @@ target_link_libraries(crazyflieLinkCpp
   PRIVATE
     ${LIBUSB_LIBRARY}
 )
-if (APPLE)
-target_link_options(crazyflieLinkCpp PUBLIC "-lobjc -framework IOKit -framework CoreFoundation")
-endif()
 set_property(TARGET crazyflieLinkCpp PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # C++ example application

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,12 +73,6 @@ add_library(crazyflieLinkCpp
 #     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/crazyflie_cpp>
 # )
 
-# Apple macOS libraries
-if (APPLE)
-  set(CMAKE_EXE_LINKER_FLAGS "-lobjc -framework IOKit -framework CoreFoundation")
-  set(CMAKE_MODULE_LINKER_FLAGS "-lobjc -framework IOKit -framework CoreFoundation")
-endif()
-
 # Link pthread on Linux and Mac only
 if (NOT MSVC)
 target_link_libraries(crazyflieLinkCpp
@@ -91,6 +85,9 @@ target_link_libraries(crazyflieLinkCpp
   PRIVATE
     ${LIBUSB_LIBRARY}
 )
+if (APPLE)
+target_link_options(crazyflieLinkCpp PUBLIC "-lobjc -framework IOKit -framework CoreFoundation")
+endif()
 set_property(TARGET crazyflieLinkCpp PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # C++ example application

--- a/include/crazyflieLinkCpp/Packet.hpp
+++ b/include/crazyflieLinkCpp/Packet.hpp
@@ -118,8 +118,13 @@ public:
     return &data_[1];
   }
 
+  void setPayloadAt(uint8_t idx, const uint8_t* data, size_t length)
+  {
+    memcpy(&payload()[idx], data, length);
+  }
+
   template<class T>
-  void setPayloadAt(uint8_t idx, T data)
+  void setPayloadAt(uint8_t idx, const T& data)
   {
     memcpy(&payload()[idx], &data, sizeof(T));
   }

--- a/include/crazyflieLinkCpp/Packet.hpp
+++ b/include/crazyflieLinkCpp/Packet.hpp
@@ -45,6 +45,14 @@ public:
     }
   }
 
+  Packet(uint8_t port, uint8_t channel, uint8_t payloadSize)
+  {
+    setPort(port);
+    setChannel(channel);
+    setPayloadSize(payloadSize);
+    seq_ = 0;
+  }
+
   bool valid() const
   {
     return size_ >= 1;
@@ -108,6 +116,28 @@ public:
   const uint8_t *payload() const
   {
     return &data_[1];
+  }
+
+  template<class T>
+  void setPayloadAt(uint8_t idx, T data)
+  {
+    memcpy(&payload()[idx], &data, sizeof(T));
+  }
+
+  template <class T>
+  T payloadAt(uint8_t idx) const
+  {
+    T data;
+    memcpy(&data, &payload()[idx], sizeof(T));
+    return data;
+  }
+
+  // Only C++ 17 would allow to overload payloadAt properly
+  // Use this version with a different name instead
+  std::string payloadAtString(uint8_t idx) const
+  {
+    std::string str((const char *)&payload()[idx], (size_t)payloadSize()-idx);
+    return str;
   }
 
   const uint8_t* raw() const

--- a/include/crazyflieLinkCpp/Packet.hpp
+++ b/include/crazyflieLinkCpp/Packet.hpp
@@ -136,7 +136,9 @@ public:
   // Use this version with a different name instead
   std::string payloadAtString(uint8_t idx) const
   {
-    std::string str((const char *)&payload()[idx], (size_t)payloadSize()-idx);
+    auto c_str = (const char *)&payload()[idx];
+    size_t length = strnlen(c_str, payloadSize() - idx);
+    std::string str(c_str, length);
     return str;
   }
 

--- a/include/crazyflieLinkCpp/Packet.hpp
+++ b/include/crazyflieLinkCpp/Packet.hpp
@@ -142,6 +142,11 @@ public:
     return str;
   }
 
+  void setPayloadAtString(uint8_t idx, const std::string& data)
+  {
+    memcpy(&payload()[idx], data.c_str(), data.size()+1);
+  }
+
   const uint8_t* raw() const
   {
     return &data_[0];

--- a/src/CrazyradioThread.cpp
+++ b/src/CrazyradioThread.cpp
@@ -194,6 +194,7 @@ void CrazyradioThread::run()
                         {
                             p = con->queue_send_.top();
                             con->queue_send_.pop();
+                            --con->statistics_.enqueued_count;
                         } else if (!con->useAutoPing_)
                         {
                             continue;
@@ -209,9 +210,11 @@ void CrazyradioThread::run()
                         con->safelinkUp_ = !con->safelinkUp_;
                         if (con->retry_) {
                             con->retry_ = Packet();
+                            --con->statistics_.enqueued_count;
                         }
                     } else {
                         con->retry_ = p;
+                        ++con->statistics_.enqueued_count;
                     }
 
                     if (ack && ack.size() > 0 && (ack.data()[0] & 0x04) == (con->safelinkDown_ << 2)) {
@@ -233,6 +236,7 @@ void CrazyradioThread::run()
                         radio.sendPacketNoAck(p.raw(), p.size());
                         ++con->statistics_.sent_count;
                         con->queue_send_.pop();
+                        --con->statistics_.enqueued_count;
                     }
                     else
                     {
@@ -241,6 +245,7 @@ void CrazyradioThread::run()
                         if (ack)
                         {
                             con->queue_send_.pop();
+                            --con->statistics_.enqueued_count;
                         }
                     }
                 }


### PR DESCRIPTION
This PR contains a number of commits with small bugfixes and an improved interface:

1. CMake: avoid building pybind11 targets by default. [Feature]
2. Packet interface: add new helper functions to simplify creating CRTP packets [Feature]
3. Statistics: Proper update of enqueued_count [Bugfix]

See also https://github.com/IMRCLab/crazyswarm2/issues/5.