### PR TITLE
Add receive() to support non-blocking operation

### DIFF
--- a/include/crazyflieLinkCpp/Connection.h
+++ b/include/crazyflieLinkCpp/Connection.h
@@ -84,6 +84,12 @@ public:
 
   void send(const Packet& p);
 
+  // Updated receive function that can be non-blocking, fully blocking, or use a timeout
+  static constexpr unsigned int TimeoutNone = 0;
+  static constexpr unsigned int TimeoutBlock = std::numeric_limits<unsigned int>::max();
+  Packet receive(unsigned int timeout_in_ms);
+
+  // Deprecated receive that can be fully blocking (timeout_in_ms == 0), or use a timeout
   Packet recv(unsigned int timeout_in_ms);
 
   void close();


### PR DESCRIPTION
* new receive() function supports no-wait, fully-blocking, or a specified timeout (recv() always waited at least 1ms)
* Mark recv() as deprecated, but don't change its semantics