### PR TITLE
Prioritize broadcast commands

### DIFF
--- a/src/CrazyradioThread.cpp
+++ b/src/CrazyradioThread.cpp
@@ -147,7 +147,30 @@ void CrazyradioThread::run()
             break;
         }
 
+        bool all_queues_empty = true;
+        bool any_outstanding_broadcasts = false;
         for (auto con : connections_copy) {
+            if (!con->queue_send_.empty() || con->retry_) {
+                all_queues_empty = false;
+                if (con->broadcast_) {
+                    any_outstanding_broadcasts = true;
+                    break;
+                }
+            }
+        }
+
+        for (auto con : connections_copy) {
+
+            // if this queue has nothing to do and we can't even send a ping, skip
+            if (con->queue_send_.empty() && !con->retry_ && (!con->useAutoPing_ || !all_queues_empty)) {
+                continue;
+            }
+
+            // if there are outstanding broadcasts, skip all non-broadcasting connections
+            if (any_outstanding_broadcasts && !con->broadcast_) {
+                continue;
+            }
+
         // for (auto con : connections_) {
             // const std::lock_guard<std::mutex> con_lock(con->alive_mutex_);
             // if (!con->alive_) {
@@ -206,7 +229,7 @@ void CrazyradioThread::run()
                             p = con->queue_send_.top();
                             con->queue_send_.pop();
                             --con->statistics_.enqueued_count;
-                        } else if (!con->useAutoPing_)
+                        } else if (!con->useAutoPing_ || !all_queues_empty)
                         {
                             continue;
                         }
@@ -260,7 +283,7 @@ void CrazyradioThread::run()
                         }
                     }
                 }
-                else if (con->useAutoPing_)
+                else if (con->useAutoPing_ && all_queues_empty)
                 {
                     ack = radio.sendPacket(ping, sizeof(ping));
                     ++con->statistics_.sent_count;


### PR DESCRIPTION
The current scheduler several issues:
1.) automatic pings are sent in a round robin fashion. For example, consider the case where we have 10 CFs, with only one being busy to send commands. Then, we will send pings to 9 CFs, artificially delaying the 1 important connection. 
=> Solution: Only send a ping if all connection queues are empty. 
2.) Broadcasts are handled like unicast connections, even though these are typically low-latency connections. 
=> Solution: Prioritize all broadcasts before sending any unicast commands 
3.) We sometimes reconfigure the radio, even if nothing needs to be done 
=> Solution: check before the radio is reconfigured