### PR TITLE
Pybind version fix for python 3.11 compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,7 +51,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/include/crazyflieLinkCpp/Connection.h
+++ b/include/crazyflieLinkCpp/Connection.h
@@ -7,7 +7,7 @@
 #include <ostream>
 #include <vector>
 #include <memory>
-
+#include <limits>
 #include "Packet.hpp"
 
 #define BROADCAST_ADDRESS 0xFFE7E7E7E7


### PR DESCRIPTION
Hey everyone!
This PR fixes #32 and bumps the pybind version to 2.10.4 to make the repo compatible with python 3.11 (https://github.com/zxing-cpp/zxing-cpp/issues/429#issuecomment-1301782210). 
The `<limits>` header was also needed because `std::numeric_limits` would throw an error.
I was able to test the build for python 3.8 to 3.11 on linux only though (don't have a mac). Let me know if I should test or change anything else.