### PR TITLE
Include string library for stricter compilers

### DIFF
--- a/src/CrazyflieUSBThread.h
+++ b/src/CrazyflieUSBThread.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <set>
+#include <string>
 #include <thread>
 #include <mutex>
 #include <condition_variable>

--- a/src/CrazyradioThread.h
+++ b/src/CrazyradioThread.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <set>
+#include <string>
 #include <thread>
 #include <mutex>
 #include <condition_variable>

--- a/src/USBManager.h
+++ b/src/USBManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <string>
 #include <vector>
 #include <mutex>
 


### PR DESCRIPTION
It is a good practice, IMO, to add the string header. Although, it is not only a good practice but newer versions of GCC and GXX complain if we don't add `include <string>` headers on these files. This is the case of Ubuntu Jammy with GCC 11 which compiles without errors but with Ubuntu Noble GCC 13 it breaks.