### PR TITLE
Add visibility properties to crazyflieLinkCpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,10 @@ target_link_libraries(crazyflieLinkCpp
     ${LIBUSB_LIBRARY}
 )
 set_property(TARGET crazyflieLinkCpp PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_target_properties(crazyflieLinkCpp PROPERTIES
+  CXX_VISIBILITY_PRESET default
+  VISIBILITY_INLINES_HIDDEN OFF
+)
 
 # C++ example application
 if (BUILD_CPP_EXAMPLES)


### PR DESCRIPTION
Set C++ visibility properties for crazyflieLinkCpp target.


This is to fix this package for Ubuntu resolute builds (https://github.com/IMRCLab/crazyswarm2/pull/848)